### PR TITLE
Set default orthography to English

### DIFF
--- a/Parsimmon/Analyzer.swift
+++ b/Parsimmon/Analyzer.swift
@@ -37,6 +37,7 @@ internal func analyze(analyzer: Analyzer, text: String, options: NSLinguisticTag
     let tagger = analyzer.seed.linguisticTaggerWithOptions(options)
 
     tagger.string = text
+    tagger.setOrthography(analyzer.seed.orthography, range: range)
     tagger.enumerateTagsInRange(range, scheme: analyzer.scheme, options: options) { (tag: String?, tokenRange, range, stop) in
         if let tag = tag {
             let token = (text as NSString).substringWithRange(tokenRange)

--- a/Parsimmon/Seed.swift
+++ b/Parsimmon/Seed.swift
@@ -27,6 +27,7 @@ public struct Seed {
 
     private let language: Language = "en"
     let linguisticTaggerOptions: NSLinguisticTaggerOptions = .OmitWhitespace | .OmitPunctuation | .OmitOther
+    let orthography = NSOrthography(dominantScript: "Latn", languageMap: ["Latn" : ["en"]])
 
     func linguisticTaggerWithOptions(options: NSLinguisticTaggerOptions) -> NSLinguisticTagger {
         let tagSchemes = NSLinguisticTagger.availableTagSchemesForLanguage(self.language)


### PR DESCRIPTION
Hey, there's [a strange bug](http://stackoverflow.com/questions/24402415/word-stemming-in-ios-not-working-for-single-word) with `NSLinguisticTagger` — it won't do word stemming for just one word (not a sentence) unless the `orthography` is set (`lemmatizeWordsInText` returns an empty array).

I've fixed this by setting the orthography to English by default. This can be expanded further by adding the user the ability to choose orthography / language.