### PR TITLE
Pipe error from xcpretty to fail travis build upon build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ before_install:
 - gem i cocoapods --no-ri --no-rdoc
 - gem i xcpretty  --no-ri --no-rdoc
 script:
-- xcodebuild -workspace ParsimmonSample.xcworkspace -scheme ParsimmonSample -sdk iphonesimulator test | xcpretty -c
+- set -o pipefail && xcodebuild -workspace ParsimmonSample.xcworkspace -scheme ParsimmonSample -sdk iphonesimulator test | xcpretty -c


### PR DESCRIPTION
Just ran into the issue mentioned in the documentation: https://github.com/supermarin/xcpretty#usage
I had copied your travis settings :wink:

Without this change Travis builds will not fail when xcodebuilds fail.